### PR TITLE
Fix certbot run command

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,6 @@ services:
     volumes:
       - ./data/certbot/www:/var/www/certbot
       - ./data/letsencrypt:/etc/letsencrypt
-    entrypoint: ''
     command: >
       certonly --webroot --webroot-path=/var/www/certbot \
       --email jpfurlan@hotmail.com.br --agree-tos --no-eff-email \


### PR DESCRIPTION
## Summary
- remove empty `entrypoint` from certbot service in `docker-compose.yml`

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_685b1865ab388329aaf635b186d715bb