### PR TITLE
Fix certbot compose command

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   web:
     build: .
@@ -14,7 +13,7 @@ services:
     volumes:
       - ./data/certbot/www:/var/www/certbot
       - ./data/letsencrypt:/etc/letsencrypt
-    command: >
-      certonly --webroot --webroot-path=/var/www/certbot \
-      --email jpfurlan@hotmail.com.br --agree-tos --no-eff-email \
+    command: >-
+      certonly --webroot --webroot-path=/var/www/certbot
+      --email jpfurlan@hotmail.com.br --agree-tos --no-eff-email
       -d jpfurlan.dev -d www.jpfurlan.dev


### PR DESCRIPTION
## Summary
- drop obsolete compose version field
- remove stray backslashes in certbot command so arguments are parsed correctly

## Testing
- `pip install pyyaml`
- `python3 -c 'import yaml, sys; yaml.safe_load(open("docker-compose.yml")); print("OK")'`

------
https://chatgpt.com/codex/tasks/task_e_685b1ad0a118832986c2f80713b346d1